### PR TITLE
Fix heap overflow in IStorageTrigger::Stat

### DIFF
--- a/IStorageTrigger.cpp
+++ b/IStorageTrigger.cpp
@@ -158,7 +158,7 @@ HRESULT IStorageTrigger::Stat(STATSTG* pstatstg, DWORD grfStatFlag) {
 	//Allocate from heap because apparently this will get freed in OLE32
 	const wchar_t c_s[] = L"JuicyPotatoNG.stg";
 	wchar_t* s = (wchar_t*)CoTaskMemAlloc(sizeof(c_s));
-	wcscpy_s(s, sizeof(c_s), c_s);
+	wcscpy_s(s, sizeof(c_s) / sizeof(wchar_t), c_s);
 	pstatstg[0].pwcsName = s;
 	return 0;
 }


### PR DESCRIPTION
The max length argument to wcscpy_s is the character count, not the byte count. Even though the size argument respected the size of the destination string, the memset call in wcscpy_s would corrupt the adjacent memory.